### PR TITLE
Regex for emails with 2+ suffix and ignoring secret-santa-list.txt

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+# Don't track the secret list!
+secret-santa-list.txt

--- a/test-validator.py
+++ b/test-validator.py
@@ -20,6 +20,10 @@ class TestValidator(unittest.TestCase):
         email = 'john.DOE+lab777@ABC-GO-NOW.AI'
         validator.validate_email(email)
 
+    def test_valid_tree_sufix(self):
+        email = 'valid@email.co.uk'
+        validator.validate_email(email)
+
     def test_invalid_basic(self):
         email = 'invalidemail.com'
         with self.assertRaises(validator.ValidateError):

--- a/validator.py
+++ b/validator.py
@@ -1,7 +1,7 @@
 import re
 
 
-email_regex = r'[^@\s]+@[a-zA-Z0-9\-]+\.[a-zA-Z0-9]+$'
+email_regex = r'[^@\s]+@[a-zA-Z0-9\-]+(\.[a-zA-Z0-9]+)+$'
 
 
 class ValidateError(Exception):


### PR DESCRIPTION
Hi.

I did a small change on the validate.py regex do it would accept emails with 2 or more suffix after the @ (e.g. valid@email.com.br or valid@email.co.uk). I also included the corresponding validation test. 

Also, I though it would be a good idea to ignore secret-santa-list.txt since it shouldn't be commited anyway and this could lead us to see its content while working on the repository code :) hope some of this suggestions contribute somehow.

Cheers!